### PR TITLE
[IBCDPE-482] Default airflow password

### DIFF
--- a/config/prod/orca-vpc.yaml
+++ b/config/prod/orca-vpc.yaml
@@ -1,10 +1,10 @@
 template:
   type: http
-  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.6.8/templates/VPC/vpc-20-private.yaml"
+  url: "{{stack_group_config.aws_infra_templates_root_url}}/v0.6.8/templates/VPC/vpc-mini.yaml"
 stack_name: orca-vpc
 
 parameters:
   VpcName: orca-vpc
-  VpcSubnetPrefix: "172.24"
+  VpcSubnetPrefix: "172.255.24"
 
 stack_tags: {{stack_group_config.default_stack_tags}}

--- a/templates/airflow-ec2.j2
+++ b/templates/airflow-ec2.j2
@@ -283,11 +283,14 @@ Resources:
           # Clone Airflow DAGs repository
           git clone https://github.com/Sage-Bionetworks-Workflows/orca-recipes-airflow.git /root/orca-recipes-airflow
 
+          # Get AWS Secret airflow_password and store as variable
+          airflow_password=$(aws secretsmanager get-secret-value --secret-id airflow_password --query SecretString --region us-east-1 | tr -d '"')
+
           #create .env file
           cp /root/orca-recipes-airflow/.env.example /root/orca-recipes-airflow/.env
 
           #add user and pass to .env
-          echo -e '_AIRFLOW_WWW_USER_USERNAME="dpe"\n_AIRFLOW_WWW_USER_PASSWORD="password"' >> /root/orca-recipes-airflow/.env
+          echo -e "_AIRFLOW_WWW_USER_USERNAME=dpe\n_AIRFLOW_WWW_USER_PASSWORD=$airflow_password" >> /root/orca-recipes-airflow/.env
 
           #Install cron
           apt-get install -y cron

--- a/templates/airflow-ec2.j2
+++ b/templates/airflow-ec2.j2
@@ -286,6 +286,9 @@ Resources:
           #create .env file
           cp /root/orca-recipes-airflow/.env.example /root/orca-recipes-airflow/.env
 
+          #add user and pass to .env
+          echo -e '_AIRFLOW_WWW_USER_USERNAME="dpe"\n_AIRFLOW_WWW_USER_PASSWORD="password"' >> /root/orca-recipes-airflow/.env
+
           #Install cron
           apt-get install -y cron
 

--- a/templates/airflow-ec2.j2
+++ b/templates/airflow-ec2.j2
@@ -284,7 +284,8 @@ Resources:
           git clone https://github.com/Sage-Bionetworks-Workflows/orca-recipes-airflow.git /root/orca-recipes-airflow
 
           # Get AWS Secret airflow_password and store as variable
-          airflow_password=$(aws --output text secretsmanager get-secret-value --secret-id airflow_password --query SecretString --region us-east-1)
+          airflow_password=$(bash /root/orca-recipes-airflow/airflow_password.sh)
+
 
           #create .env file
           cp /root/orca-recipes-airflow/.env.example /root/orca-recipes-airflow/.env

--- a/templates/airflow-ec2.j2
+++ b/templates/airflow-ec2.j2
@@ -284,7 +284,7 @@ Resources:
           git clone https://github.com/Sage-Bionetworks-Workflows/orca-recipes-airflow.git /root/orca-recipes-airflow
 
           # Get AWS Secret airflow_password and store as variable
-          airflow_password=$(aws secretsmanager get-secret-value --secret-id airflow_password --query SecretString --region us-east-1 | tr -d '"')
+          airflow_password=$(aws --output text secretsmanager get-secret-value --secret-id airflow_password --query SecretString --region us-east-1)
 
           #create .env file
           cp /root/orca-recipes-airflow/.env.example /root/orca-recipes-airflow/.env


### PR DESCRIPTION
This PR adds to the `airflow-ec2.yaml` template to set the default airflow username to 'dpe' and the default password to the one stored in AWS secrets manager. In order to do that, I used an `aws` cli command to retrieve the secret, and then `echo` to append the new username "dpe" and the password `airflow_password` from the secrets backend (the one in last pass) to `.env`. This way we don't need to execute a command in the `webserver` docker container after it is already running, and the cloudformation template only needs minor edits. I successfully tested this template in `dpe-prod`, and I tested setting the username and password manually via `.env` in codespaces, although this won't be necessary when developing in a codespace.