### PR TITLE
[ORCA-292] Increase Airflow EC2 Storage Volume Size

### DIFF
--- a/templates/airflow-ec2.j2
+++ b/templates/airflow-ec2.j2
@@ -36,7 +36,7 @@ Parameters:
   VolumeSize:
     Description: The EC2 volume size (in GB)
     Type: Number
-    Default: 20
+    Default: 250
     MinValue: 10
     MaxValue: 2000
 


### PR DESCRIPTION
**Problem:**

Recently, Airflow has failed to spin up due to a lack of storage space on the EC2 instance. The storage volume attached to our Airflow EC2 instance is currently quite small (20GB). Because Airflow alone requires >10GB of storage space for it to run properly, it makes sense to increase this to a more comfortable size.

**Solution:**

Increase the default value of `VolumeSize` to 250GB to ensure we have plenty of space for Airflow to run consistently.